### PR TITLE
chore: bump Home Assistant from 2026.2.3 to 2026.3.1

### DIFF
--- a/startos/install/versions/index.ts
+++ b/startos/install/versions/index.ts
@@ -1,2 +1,2 @@
-export { v_2026_2_3_1_b0 as current } from './v2026.2.3.1.b0'
+export { v_2026_3_1_1_b0 as current } from './v2026.3.1.1.b0'
 export const other = []

--- a/startos/install/versions/v2026.3.1.1.b0.ts
+++ b/startos/install/versions/v2026.3.1.1.b0.ts
@@ -1,0 +1,16 @@
+import { VersionInfo } from '@start9labs/start-sdk'
+
+export const v_2026_3_1_1_b0 = VersionInfo.of({
+  version: '2026.3.1:1-beta.0',
+  releaseNotes: {
+    en_US: 'Update Home Assistant from 2026.2.3 to 2026.3.1',
+    es_ES: 'Actualización de Home Assistant de 2026.2.3 a 2026.3.1',
+    de_DE: 'Update Home Assistant von 2026.2.3 auf 2026.3.1',
+    pl_PL: 'Aktualizacja Home Assistant z 2026.2.3 do 2026.3.1',
+    fr_FR: 'Mise à jour de Home Assistant de 2026.2.3 à 2026.3.1',
+  },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: async ({ effects }) => {},
+  },
+})

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   volumes: ['main', 'config'],
   images: {
     'home-assistant': {
-      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.2.3' },
+      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.3.1' },
       arch: ['x86_64', 'aarch64'],
     },
   },


### PR DESCRIPTION
## Summary

Bumps Home Assistant from **2026.2.3** to **2026.3.1** (minor release).

## Upstream Changes (2026.3)

- Vacuum area cleaning, energy dashboard improvements, Python 3.14 support
- 17 new integrations
- 2026.3.1 patch: 24 bug fixes

## Breaking Changes

- **`color_temp` (mireds) removed** — `color_temp_kelvin` is now the only supported attribute for light color temperature. Any automations or scripts using mireds must be updated to use Kelvin values.
- **Container images now use zstd compression** — requires Docker 23.0+ on the host. StartOS environments should verify Docker version compatibility.

## Changes

- Updated Docker image tag in `startos/manifest/index.ts`
- Added new version entry `v2026.3.1.1.b0`

## Links

- [2026.3 Release Notes](https://www.home-assistant.io/blog/2026/03/05/release-20263/)
- [2026.3.1 Patch Notes](https://github.com/home-assistant/core/releases/tag/2026.3.1)