### PR TITLE
Bump to 2026.5.2:1 — Home Assistant 2026.5.2, start-sdk 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "home-assistant-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.0",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -342,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1"
+    "@start9labs/start-sdk": "1.5.2"
   },
   "devDependencies": {
     "@types/node": "^22.19.0",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -13,7 +13,7 @@ export const manifest = setupManifest({
   volumes: ['main', 'config'],
   images: {
     'home-assistant': {
-      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.1' },
+      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.2' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,8 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_2026_4_2_1 } from './v2026.4.2_1'
-import { v_2026_5_1_1 } from './v2026.5.1_1'
+import { v_2026_5_2_1 } from './v2026.5.2_1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2026_5_1_1,
+  current: v_2026_5_2_1,
   other: [v_2026_4_2_1],
 })

--- a/startos/versions/v2026.5.2_1.ts
+++ b/startos/versions/v2026.5.2_1.ts
@@ -4,29 +4,19 @@ import { configurationYaml } from '../fileModels/configuration.yaml'
 import { regenerateDefaults } from '../init/bootstrapHa'
 import { sdk } from '../sdk'
 
-export const v_2026_5_1_1 = VersionInfo.of({
-  version: '2026.5.1:1',
+export const v_2026_5_2_1 = VersionInfo.of({
+  version: '2026.5.2:1',
   releaseNotes: {
-    en_US: `**Bumps**
-
-- Home Assistant → 2026.5.1
-- start-sdk → 1.5.0`,
-    es_ES: `**Actualizaciones**
-
-- Home Assistant → 2026.5.1
-- start-sdk → 1.5.0`,
-    de_DE: `**Aktualisierungen**
-
-- Home Assistant → 2026.5.1
-- start-sdk → 1.5.0`,
-    pl_PL: `**Aktualizacje**
-
-- Home Assistant → 2026.5.1
-- start-sdk → 1.5.0`,
-    fr_FR: `**Mises à jour**
-
-- Home Assistant → 2026.5.1
-- start-sdk → 1.5.0`,
+    en_US: `- Home Assistant → 2026.5.2
+- start-sdk → 1.5.2`,
+    es_ES: `- Home Assistant → 2026.5.2
+- start-sdk → 1.5.2`,
+    de_DE: `- Home Assistant → 2026.5.2
+- start-sdk → 1.5.2`,
+    pl_PL: `- Home Assistant → 2026.5.2
+- start-sdk → 1.5.2`,
+    fr_FR: `- Home Assistant → 2026.5.2
+- start-sdk → 1.5.2`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- **Home Assistant**: 2026.5.1 → 2026.5.2 (upstream patch release — bug fixes across integrations: LG ThinQ, SmartThings, Comelit, MQTT, Shelly, Matter climate, energy, esphome, etc.; one breaking change scoped to the Duco integration's switch to `python-duco-connectivity` and removal of temperature sensors).
- **@start9labs/start-sdk**: 1.5.1 → 1.5.2. The fix stages `pg_dump`/`mysqldump` output through the subcontainer rootfs before copying into the backup target — direct writes to the `backup-fs` FUSE mount were being silently dropped. This package only uses `Backups.ofVolumes`, so the change is no-op for us; bumping along with siblings for consistency.

Patch bump only; version file renamed in place. The 2026.4.2:1 → :2 `configuration.yaml` repair migration is carried forward for any users still on that older revision.

## Test plan

- [x] `make` produces both `home-assistant_x86_64.s9pk` and `home-assistant_aarch64.s9pk` cleanly with SDK 1.5.2.