### PR TITLE
chore: bump Home Assistant to 2026.5.3; 2026.5.2:1 → 2026.5.3:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -13,7 +13,7 @@ export const manifest = setupManifest({
   volumes: ['main', 'config'],
   images: {
     'home-assistant': {
-      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.2' },
+      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.3' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,8 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_2026_4_2_1 } from './v2026.4.2_1'
-import { v_2026_5_2_1 } from './v2026.5.2_1'
+import { v_2026_5_3_0 } from './v2026.5.3_0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2026_5_2_1,
+  current: v_2026_5_3_0,
   other: [v_2026_4_2_1],
 })

--- a/startos/versions/v2026.5.3_0.ts
+++ b/startos/versions/v2026.5.3_0.ts
@@ -4,19 +4,14 @@ import { configurationYaml } from '../fileModels/configuration.yaml'
 import { regenerateDefaults } from '../init/bootstrapHa'
 import { sdk } from '../sdk'
 
-export const v_2026_5_2_1 = VersionInfo.of({
-  version: '2026.5.2:1',
+export const v_2026_5_3_0 = VersionInfo.of({
+  version: '2026.5.3:0',
   releaseNotes: {
-    en_US: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    es_ES: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    de_DE: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    pl_PL: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    fr_FR: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
+    en_US: 'Bumps Home Assistant → 2026.5.3.',
+    es_ES: 'Actualiza Home Assistant → 2026.5.3.',
+    de_DE: 'Aktualisiert Home Assistant → 2026.5.3.',
+    pl_PL: 'Aktualizuje Home Assistant → 2026.5.3.',
+    fr_FR: 'Met à jour Home Assistant → 2026.5.3.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps Home Assistant Core: **2026.5.2 → 2026.5.3** (upstream patch release; bug fixes across integrations — see [upstream release notes](https://github.com/home-assistant/core/releases/tag/2026.5.3)).
- StartOS package version: **2026.5.2:1 → 2026.5.3:0** (new upstream resets the StartOS revision to `:0`).
- No SDK bump (`@start9labs/start-sdk` 1.5.2 is current).
- No migration required for this patch bump; the prior version's `up` migration (`configuration.yaml` carry-forward for users still on 2026.4.2:1) is preserved in the renamed file.

## Test plan

- [x] \`make\` builds both \`home-assistant_x86_64.s9pk\` and \`home-assistant_aarch64.s9pk\` at \`v2026.5.3:0\`.
- [x] Fresh install of the x86_64 \`.s9pk\` on a clean StartOS test VM completes successfully; service starts and serves the Home Assistant onboarding page on the assigned HTTPS port.