### PR TITLE
chore: bump Home Assistant to 2026.5.3; bump start-sdk to 1.5.3; 2026.5.2:1 → 2026.5.3:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "home-assistant-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.2"
+        "@start9labs/start-sdk": "1.5.3"
       },
       "devDependencies": {
         "@types/node": "^22.19.0",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
-      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.3.tgz",
+      "integrity": "sha512-OyHe9J6hMvyA5ZavcLkxdVQvZcuTH9J9kagV6NDI83eAG/YpJFIq62gP/n/2PPNdHWwNSXVQmSwnsvsV8Gyg+A==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.2"
+    "@start9labs/start-sdk": "1.5.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.0",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -13,7 +13,7 @@ export const manifest = setupManifest({
   volumes: ['main', 'config'],
   images: {
     'home-assistant': {
-      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.2' },
+      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.3' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,8 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_2026_4_2_1 } from './v2026.4.2_1'
-import { v_2026_5_2_1 } from './v2026.5.2_1'
+import { v_2026_5_3_0 } from './v2026.5.3_0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2026_5_2_1,
+  current: v_2026_5_3_0,
   other: [v_2026_4_2_1],
 })

--- a/startos/versions/v2026.5.3_0.ts
+++ b/startos/versions/v2026.5.3_0.ts
@@ -4,19 +4,19 @@ import { configurationYaml } from '../fileModels/configuration.yaml'
 import { regenerateDefaults } from '../init/bootstrapHa'
 import { sdk } from '../sdk'
 
-export const v_2026_5_2_1 = VersionInfo.of({
-  version: '2026.5.2:1',
+export const v_2026_5_3_0 = VersionInfo.of({
+  version: '2026.5.3:0',
   releaseNotes: {
-    en_US: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    es_ES: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    de_DE: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    pl_PL: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
-    fr_FR: `- Home Assistant → 2026.5.2
-- start-sdk → 1.5.2`,
+    en_US: `- Home Assistant → 2026.5.3
+- start-sdk → 1.5.3`,
+    es_ES: `- Home Assistant → 2026.5.3
+- start-sdk → 1.5.3`,
+    de_DE: `- Home Assistant → 2026.5.3
+- start-sdk → 1.5.3`,
+    pl_PL: `- Home Assistant → 2026.5.3
+- start-sdk → 1.5.3`,
+    fr_FR: `- Home Assistant → 2026.5.3
+- start-sdk → 1.5.3`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- **Home Assistant 2026.5.2 → 2026.5.3** — upstream patch release. Bug fixes only across many integrations (Overkiz, blebox, Apple TV, utility_meter, threshold, weatherflow_cloud, ZHA, …) plus a few dependency bumps. No behavior changes that the package surface (image + config layout) has to react to. [Release notes](https://github.com/home-assistant/core/releases/tag/2026.5.3).
- **`@start9labs/start-sdk` 1.5.2 → 1.5.3** — patch.
- **StartOS version: 2026.5.2:1 → 2026.5.3:0.** New upstream resets the StartOS revision to `:0`. Version file renamed in place; the existing 2026.4.2:1 → :2 `configuration.yaml` carry-forward migration is preserved for users still on 2026.4.2:1.

## Test plan

- [x] `npm install` + `npm update` clean
- [x] `npm run check` passes
- [x] `make` builds both `home-assistant_x86_64.s9pk` (v2026.5.3:0, SDK 1.5.3) and `home-assistant_aarch64.s9pk`
- [x] Sideloaded the x86_64 build onto a fresh StartOS 0.4.0-beta.9 VM; package installed cleanly, started, HA listened on 8123 and served `/onboarding.html` with a 200