### PR TITLE
chore: bump Home Assistant to 2026.5.4; 2026.5.3:0 → 2026.5.4:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -13,7 +13,7 @@ export const manifest = setupManifest({
   volumes: ['main', 'config'],
   images: {
     'home-assistant': {
-      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.3' },
+      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.4' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,8 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_2026_4_2_1 } from './v2026.4.2_1'
-import { v_2026_5_3_0 } from './v2026.5.3_0'
+import { v_2026_5_4_0 } from './v2026.5.4_0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2026_5_3_0,
+  current: v_2026_5_4_0,
   other: [v_2026_4_2_1],
 })

--- a/startos/versions/v2026.5.4_0.ts
+++ b/startos/versions/v2026.5.4_0.ts
@@ -4,19 +4,14 @@ import { configurationYaml } from '../fileModels/configuration.yaml'
 import { regenerateDefaults } from '../init/bootstrapHa'
 import { sdk } from '../sdk'
 
-export const v_2026_5_3_0 = VersionInfo.of({
-  version: '2026.5.3:0',
+export const v_2026_5_4_0 = VersionInfo.of({
+  version: '2026.5.4:0',
   releaseNotes: {
-    en_US: `- Home Assistant → 2026.5.3
-- start-sdk → 1.5.3`,
-    es_ES: `- Home Assistant → 2026.5.3
-- start-sdk → 1.5.3`,
-    de_DE: `- Home Assistant → 2026.5.3
-- start-sdk → 1.5.3`,
-    pl_PL: `- Home Assistant → 2026.5.3
-- start-sdk → 1.5.3`,
-    fr_FR: `- Home Assistant → 2026.5.3
-- start-sdk → 1.5.3`,
+    en_US: 'Bumps Home Assistant → 2026.5.4.',
+    es_ES: 'Actualiza Home Assistant → 2026.5.4.',
+    de_DE: 'Aktualisiert Home Assistant → 2026.5.4.',
+    pl_PL: 'Aktualizuje Home Assistant → 2026.5.4.',
+    fr_FR: 'Met à jour Home Assistant → 2026.5.4.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps Home Assistant Core 2026.5.3 → 2026.5.4 (upstream patch release: bug fixes across integrations including OpenAI Conversation, Lyric, Roborock, Miele, ZHA, SmartThings, Habitica, PowerView, Wyoming, Shelly, WLED, Hue, Insteon, and more).
- StartOS revision resets to `:0` → `2026.5.4:0`.
- `start-sdk` already at the latest published version (1.5.3); `npm update` was a no-op.

## Test plan

- [x] `make` builds both `home-assistant_x86_64.s9pk` and `home-assistant_aarch64.s9pk` cleanly (SDK 1.5.3, version `2026.5.4:0`).
- [x] Sideload-install of the x86_64 `.s9pk` on a fresh StartOS beta-9 VM succeeds.
- [x] Service starts; Home Assistant onboarding page is reachable on the internal port 8123.