### PR TITLE
chore: bump Home Assistant to 2026.6.0; 2026.5.4:1 → 2026.6.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -13,7 +13,7 @@ export const manifest = setupManifest({
   volumes: ['main', 'config'],
   images: {
     'home-assistant': {
-      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.5.4' },
+      source: { dockerTag: 'ghcr.io/home-assistant/home-assistant:2026.6.0' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,13 @@
 import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2026.5.4:1',
+  version: '2026.6.0:0',
   releaseNotes: {
-    en_US:
-      'Add Set Up HACS and Remove HACS actions for the Home Assistant Community Store.',
-    es_ES:
-      'Añade las acciones Configurar HACS y Eliminar HACS para Home Assistant Community Store.',
-    de_DE:
-      'Fügt die Aktionen „HACS einrichten“ und „HACS entfernen“ für den Home Assistant Community Store hinzu.',
-    pl_PL:
-      'Dodaje akcje „Skonfiguruj HACS“ i „Usuń HACS“ dla Home Assistant Community Store.',
-    fr_FR:
-      'Ajoute les actions « Configurer HACS » et « Supprimer HACS » pour le Home Assistant Community Store.',
+    en_US: 'Updates Home Assistant to 2026.6.0.',
+    es_ES: 'Actualiza Home Assistant a 2026.6.0.',
+    de_DE: 'Aktualisiert Home Assistant auf 2026.6.0.',
+    pl_PL: 'Aktualizuje Home Assistant do 2026.6.0.',
+    fr_FR: 'Met à jour Home Assistant vers 2026.6.0.',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

- Bumps Home Assistant Core to **2026.6.0** (`ghcr.io/home-assistant/home-assistant:2026.6.0`), the latest stable upstream release.
- StartOS version: `2026.5.4:1` → `2026.6.0:0` (revision resets to `:0` on a new upstream version).
- `npm update` refreshed transitive deps; `@start9labs/start-sdk` already at the latest `1.5.3`.

No migration is required — this is a routine monthly upstream bump with no schema or behavior changes on the StartOS side. No actions, ports, volumes, interfaces, or dependencies changed, so README/instructions need no updates.

## Test plan

- [x] `npm run check` (tsc --noEmit) is green.
- [ ] `make` build + s9pk pack verified in review.